### PR TITLE
fix(it): restore runITs compileability after dependency/API drift

### DIFF
--- a/mondrian/src/it/java/mondrian/rolap/BatchTestCase.java
+++ b/mondrian/src/it/java/mondrian/rolap/BatchTestCase.java
@@ -195,7 +195,9 @@ public class BatchTestCase extends FoodMartTestCase {
                             ((RolapConnection)getConnection()).getServer()
                                 .getAggregationManager().cacheMgr,
                             cube.getStar().getSqlQueryDialect(),
-                            cube);
+                            cube,
+                            new HashMap<>(),
+                            new HashMap<>());
                     BatchLoader.Batch batch =
                         createBatch(
                             fbcr,

--- a/mondrian/src/it/java/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -70,7 +70,9 @@ public class FastBatchingCellReaderTest extends BatchTestCase {
     if ( useGroupingSets != null ) {
       dialect = dialectWithGroupingSets( dialect, useGroupingSets );
     }
-    return new BatchLoader( Locus.peek(), aggMgr.cacheMgr, dialect, cube );
+    return new BatchLoader(
+        Locus.peek(), aggMgr.cacheMgr, dialect, cube,
+        new HashMap<>(), new HashMap<>() );
   }
 
   private Dialect dialectWithGroupingSets( final Dialect dialect, final boolean supportsGroupingSets ) {

--- a/mondrian/src/it/java/mondrian/rolap/RolapConnectionTest.java
+++ b/mondrian/src/it/java/mondrian/rolap/RolapConnectionTest.java
@@ -22,7 +22,7 @@ import mondrian.util.Pair;
 
 import junit.framework.TestCase;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/mondrian/src/it/java/mondrian/test/loader/MondrianFoodMartLoader.java
+++ b/mondrian/src/it/java/mondrian/test/loader/MondrianFoodMartLoader.java
@@ -16,7 +16,7 @@ import mondrian.rolap.RolapUtil;
 import mondrian.spi.Dialect;
 import mondrian.spi.DialectManager;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;


### PR DESCRIPTION
## Summary

Restores `src/it/java` compileability under `runITs` after dependency/API drift.

Changes:
- Migrates lingering IT imports from `org.apache.commons.lang.StringUtils` to `org.apache.commons.lang3.StringUtils`.
- Updates two `FastBatchingCellReader.BatchLoader` IT call sites to use the current 6-argument constructor.

## Scope

Maintenance-only. No production behavior changes.

## Verification

- `runITs` IT-classes compile step now passes.
- Previous blockers are gone:
  - missing legacy `commons-lang`
  - stale 4-arg `BatchLoader` constructor calls

Runtime IT execution is still blocked by an environment issue:
- MySQL spinup / docker-in-docker socket problem

## Context

This unblocks later runtime verification of Phase 8d's XMLA Discover telemetry IT:

```bash
mvn verify -DrunITs \
  -Dit.test=XmlaDiscoverNativeSqlTelemetryTest \
  -Dmaven.test.failure.ignore=true
```