### PR TITLE
Session: remove statements on close

### DIFF
--- a/mondrian/src/main/java/mondrian/server/Session.java
+++ b/mondrian/src/main/java/mondrian/server/Session.java
@@ -22,6 +22,7 @@ import mondrian.rolap.RolapSchema;
 import mondrian.rolap.RolapSchemaPool;
 import mondrian.rolap.agg.SegmentCacheManager;
 import mondrian.rolap.agg.SegmentCacheWorker;
+import mondrian.olap.MondrianException;
 import mondrian.olap.MondrianServer;
 import org.olap4j.Scenario;
 
@@ -131,12 +132,31 @@ public class Session
             }
         }
 
+        removeStatements(sessionId);
+
         Session session = sessions.remove(sessionId);
         if(session != null) {
             shutdownCacheManager(session);
         }
 
         mondrian.metrics.SessionMetrics.setSessionCount(sessions.size());
+    }
+
+    private static void removeStatements(String sessionId) {
+        for (MondrianServerImpl server
+            : new ArrayList<MondrianServerImpl>(MondrianServerImpl.getServers()))
+        {
+            for (Statement statement : server.getStatements(sessionId)) {
+                try {
+                    server.removeStatement(statement);
+                } catch (MondrianException e) {
+                    LOGGER.debug(
+                        "Skipped statement cleanup for closed session "
+                            + sessionId,
+                        e);
+                }
+            }
+        }
     }
 
     static void shutdownCacheManager(Session session) {

--- a/mondrian/src/test/java/mondrian/server/SessionStatementCleanupTest.java
+++ b/mondrian/src/test/java/mondrian/server/SessionStatementCleanupTest.java
@@ -1,0 +1,68 @@
+package mondrian.server;
+
+import mondrian.olap.MondrianServer;
+import mondrian.olap.Util;
+import mondrian.rolap.RolapConnection;
+import mondrian.spi.CatalogLocator;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SessionStatementCleanupTest {
+
+    @Test public void closeInternalRemovesOnlyStatementsForSession()
+        throws Exception
+    {
+        final MondrianServerImpl server = new MondrianServerImpl(
+            new MondrianServerRegistry(),
+            mock(Repository.class),
+            mock(CatalogLocator.class));
+        final String sessionId = "session-cleanup-"
+            + UUID.randomUUID().toString();
+        final String otherSessionId = sessionId + "-other";
+
+        try {
+            Session.create(sessionId);
+            Session.create(otherSessionId);
+
+            server.addStatement(statement(101L, server, sessionId));
+            server.addStatement(statement(102L, server, sessionId));
+            server.addStatement(statement(201L, server, otherSessionId));
+
+            assertEquals(2, server.getStatements(sessionId).size());
+            assertEquals(1, server.getStatements(otherSessionId).size());
+
+            Session.closeInternal(sessionId);
+
+            assertEquals(0, server.getStatements(sessionId).size());
+            assertEquals(1, server.getStatements(otherSessionId).size());
+        } finally {
+            Session.closeInternal(sessionId);
+            Session.closeInternal(otherSessionId);
+            MondrianServerImpl.getServers().remove(server);
+        }
+    }
+
+    private static Statement statement(
+        long id,
+        MondrianServer server,
+        String sessionId)
+    {
+        final Statement statement = mock(Statement.class);
+        final RolapConnection connection = mock(RolapConnection.class);
+        final Util.PropertyList connectInfo = new Util.PropertyList();
+        connectInfo.put("sessionId", sessionId);
+
+        when(connection.getConnectInfo()).thenReturn(connectInfo);
+        when(connection.getServer()).thenReturn(server);
+        when(connection.getId()).thenReturn((int) id);
+        when(statement.getId()).thenReturn(id);
+        when(statement.getMondrianConnection()).thenReturn(connection);
+        return statement;
+    }
+}


### PR DESCRIPTION
## Purpose

Clean up statements associated with an XMLA/Mondrian session when the session is closed.

This ports the useful part of upstream `SergeiSemenkov/mondrian` `cfb26c24d` manually: the statement cleanup on session close. Our `getStatements(sessionId)` implementation was already null-safe, so this PR keeps that code and only adds the missing lifecycle cleanup.

## Changes

- `Session.closeInternal(sessionId)` now removes statements belonging to the closing session from active `MondrianServerImpl` instances.
- Adds `SessionStatementCleanupTest` to verify closing one session removes only that session's statements and leaves other sessions intact.

## Validation

- `./scripts/mondrian-unit-test.sh SessionStatementCleanupTest`

## Links

- Tracking issue: dronsv/emondrian-clickhouse#66
- Upstream reference: https://github.com/SergeiSemenkov/mondrian/commit/cfb26c24d563c6e9ada154ed665e3ab91068cb72